### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/lookbusy1344/UnmanagedStringPool/security/code-scanning/1](https://github.com/lookbusy1344/UnmanagedStringPool/security/code-scanning/1)

To fix this issue, we should add a `permissions` block at the root of the workflow YAML for minimal required access, which is `contents: read`. This will ensure that the automatically generated `GITHUB_TOKEN` only has read access to repository contents for all jobs in this workflow, unless individual jobs override it. The `permissions` block should be added at the top level, anywhere after the `name:` and before `jobs:`. No other modifications are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
